### PR TITLE
Changed cutting away of MSB to cutting the LSBs away

### DIFF
--- a/image2coe.py
+++ b/image2coe.py
@@ -81,9 +81,9 @@ def Convert (ImageName):
 			# '0b' part and left filling zeros until the string represents 8 bits
 			# then slice off the bits of interest with [5:] for red and green
 			# or [6:] for blue
-			Rb = bin(R)[2:].zfill(8)[5:]
-			Gb = bin(G)[2:].zfill(8)[5:]
-			Bb = bin(B)[2:].zfill(8)[6:]
+			Rb = bin(R)[2:].zfill(8)[:3]
+			Gb = bin(G)[2:].zfill(8)[:3]
+			Bb = bin(B)[2:].zfill(8)[:2]
 			
 			Outbyte = Rb+Gb+Bb
 			# Check for Value Error, happened when the case of the pixel being 


### PR DESCRIPTION
The script cut away the MSBs and stored only the 3 (red, green) and 2 (blue) least significant bits. This results in a very colorful but wrong colored image. The change fixes this and only stores the MSBs for the coe-file. 
